### PR TITLE
Add px as unit values for margin

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -19,12 +19,12 @@
 }
 
 #emoji_append_list_preview_label {
-  margin: 5;
+  margin: 5px;
   font-weight: bold;
 }
 
 #emoji_append_list_preview {
-  margin-bottom: 10;
+  margin-bottom: 10px;
   font-size: 16px;
 }
 


### PR DESCRIPTION
Fixed theme parser error as not using units is deprecated.

This will make sure the following warning messages don't appear in the console.
```bash
(-m:98174): Gtk-WARNING **: 00:38:43.460: Theme parsing error: style.css:22:11: Not using units is deprecated. Assuming 'px'.

(-m:98174): Gtk-WARNING **: 00:38:43.460: Theme parsing error: style.css:27:19: Not using units is deprecated. Assuming 'px'.

```