### PR TITLE
feat: automatically paste emoji into focussed app

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 Emote is a modern emoji picker for Linux 🚀. Written in GTK3, Emote is lightweight and stays out of your way.
 
-Launch the emoji picker with the configurable keyboard shortcut Ctrl+Alt+E and select one or more emojis to copy them to your clipboard.
+Launch the emoji picker with the configurable keyboard shortcut `Ctrl+Alt+E` and select one or more emojis to have them be automatically pasted into your currently focussed app.
+
+Note - Emote is currently only compatible with X11.
 
 <p align="center">
   <img width="500" src="https://raw.githubusercontent.com/tom-james-watson/Emote/master/images/screenshot.png">
@@ -35,7 +37,7 @@ The emoji picker can be opened with either the keyboard shortcut or by clicking 
 
 ### Usage
 
-Select an emoji to copy it to your clipboard. You can then paste the emoji wherever you need.
+Select an emoji to and have it be pasted to your currently focussed app. The emoji will also be copied to your clipboard, so you can then paste the emoji wherever you need.
 
 You can select multiple emojis by selecting them with right click.
 
@@ -129,8 +131,8 @@ snapcraft push --release=edge <path to .snap>
 
 ### App Icon
 
-Copyright 2020 Twitter, Inc and other contributors
+Copyright 2020 Twitter, Inc and other contributors.
 
-Thanks for the awesome team at Twitter.
+Thanks to the awesome team at Twitter.
 
 https://twemoji.twitter.com

--- a/emote/guide.py
+++ b/emote/guide.py
@@ -58,8 +58,9 @@ class Guide(Gtk.Dialog):
 
         copying = Gtk.Label()
         copying.set_markup(
-            "Select an emoji to copy it to your clipboard. You can then paste the\n"
-            "emoji wherever you need."
+            "Select an emoji to have it pasted to your currently focussed app. The\n"
+            "emoji is also copied to the clipboard so you can then paste the emoji\n"
+            "wherever you need."
         )
         copying.set_line_wrap(True)
         copying.set_alignment(0, 0.5)

--- a/emote/picker.py
+++ b/emote/picker.py
@@ -1,4 +1,5 @@
 import os
+import time
 from datetime import datetime
 import gi
 
@@ -49,7 +50,6 @@ class EmojiPicker(Gtk.Window):
 
     def init_header(self):
         header = Gtk.HeaderBar(title="Emote")
-        header.set_subtitle("Select an emoji to copy it")
 
         self.menu_popover = Gtk.Popover()
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -441,10 +441,11 @@ class EmojiPicker(Gtk.Window):
 
     def on_emoji_select(self, emoji):
         """
-        Copy the selected emoji to the clipboard and exit
+        Copy the selected emoji to the clipboard, close the picker window and
+        make the user's system perform a paste after 150ms, pasting the emoji
+        to the currently focussed application window.
 
-        If we have been appending other emojis first, add this final one and
-        copy out all.
+        If we have been appending other emojis first, add this final one first.
         """
         self.hide()
 
@@ -456,6 +457,9 @@ class EmojiPicker(Gtk.Window):
             self.copy_to_clipboard(emoji)
 
         self.destroy()
+
+        time.sleep(0.15)
+        os.system("xdotool key ctrl+v")
 
     def add_emoji_to_recent(self, emoji):
         user_data.update_recent_emojis(emoji)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: emote
-version: '1.3.0'
+version: '1.4.0'
 license: GPL-3.0+
 summary: Modern emoji picker built on GTK3
 description: |
@@ -28,6 +28,7 @@ parts:
     build-packages:
       - libgirepository1.0-dev
     stage-packages:
+      - xdotool
       - libcairo-gobject2
       - libcairo2
       - libfontconfig1


### PR DESCRIPTION
I had had trouble finding a way to get this working whilst the app was
packaged as a snap. Turned out it was as easy as using xdotool and
ensuring that is bundled into the snap file.

Closes https://github.com/tom-james-watson/Emote/issues/13