### PR TITLE
Use ydotool do paste under wayland

### DIFF
--- a/emote/picker.py
+++ b/emote/picker.py
@@ -576,7 +576,9 @@ class EmojiPicker(Gtk.Window):
 
         time.sleep(0.15)
 
-        if not config.is_wayland:
+        if config.is_wayland:
+            os.system("ydotool key control+v")
+        else:
             os.system("xdotool key ctrl+v")
 
     def add_emoji_to_recent(self, emoji):


### PR DESCRIPTION
This PR adds support to paste contents of the clipboard under Wayland using [ydotool](https://github.com/ReimuNotMoe/ydotool).

Note: I installed Emote version 2.0.0 from [AUR](https://aur.archlinux.org/packages/emote) and have not verified this patch to be working when installed from Snap. Please let me know what additional tests should be done.