### PR TITLE
Feature/paste support wayland

### DIFF
--- a/emote/picker.py
+++ b/emote/picker.py
@@ -576,7 +576,9 @@ class EmojiPicker(Gtk.Window):
 
         time.sleep(0.15)
 
-        if not config.is_wayland:
+        if config.is_wayland:
+            os.system("ydotool key control+v")
+        else:
             os.system("xdotool key ctrl+v")
 
     def add_emoji_to_recent(self, emoji):

--- a/emote/picker.py
+++ b/emote/picker.py
@@ -577,7 +577,7 @@ class EmojiPicker(Gtk.Window):
         time.sleep(0.15)
 
         if config.is_wayland:
-            os.system("ydotool key control+v")
+            os.system("ydotool key ctrl+v")
         else:
             os.system("xdotool key ctrl+v")
 


### PR DESCRIPTION
Following up on #32. Renamed the branch in my copy and hadn't realized that the PR would be closed as a result.

To summarize

> Hi - thanks for the PR! I actually already tried exactly this but had to abandon it. See #27 for more info, but basically ydotool requires root access to /dev/uinput or for you to run `ytoold` as root.

As stated in [this comment](https://github.com/ReimuNotMoe/ydotool/issues/36#issuecomment-624629221), that can be fixed by adding a udev role. This rule was added to the Arch Linux AUR package last weekend.[1]
I should actually make that a PR upstream.

> I had intended to look into this again at some point to see what other options there are, for example it looks like maybe https://github.com/bugaevc/wl-clipboard could be a better choice. My problem is that I have an nvidia machine so testing Wayland stuff is a bit of a pain for me. If you like you can see if you can get it working with `wl-clipboard`?

I looked at it and it doesn't seem to be useful. From `wl-clipboard(1)`:

> *wl-paste* pastes data from the Wayland clipboard to its standard output.

[1] https://aur.archlinux.org/cgit/aur.git/commit/80-uinput.rules?h=ydotool&id=7a554189a71247ae4de37f00da40ff916ca14136