### PR TITLE
fix: typo in guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Emote is a modern emoji picker for Linux 🚀. Written in GTK3, Emote is lightweight and stays out of your way.
 
-Launch the emoji picker with the configurable keyboard shortcut `Ctrl+Alt+E` and select one or more emojis to have them be automatically pasted into your currently focussed app.
+Launch the emoji picker with the configurable keyboard shortcut `Ctrl+Alt+E` and select one or more emojis to have them be automatically pasted into your currently focused app.
 
 Note - Emote under Wayland cannot automatically paste the emoji into other apps and also requires manual registering of a global keyboard shortcut - [Hotkey In Wayland](https://github.com/tom-james-watson/Emote/wiki/Hotkey-In-Wayland). This is due to intentional restrictions in the design of Wayland itself.
 
@@ -39,7 +39,7 @@ The emoji picker can be opened with either the keyboard shortcut or by clicking 
 
 ### Usage
 
-Select an emoji to and have it be pasted to your currently focussed app. The emoji will also be copied to your clipboard, so you can then paste the emoji wherever you need.
+Select an emoji to and have it be pasted to your currently focused app. The emoji will also be copied to your clipboard, so you can then paste the emoji wherever you need.
 
 You can select multiple emojis by selecting them with right click.
 

--- a/emote/guide.py
+++ b/emote/guide.py
@@ -78,7 +78,7 @@ class Guide(Gtk.Dialog):
         else:
             copying = Gtk.Label()
             copying.set_markup(
-                "Select an emoji to have it pasted to your currently focussed app. The\n"
+                "Select an emoji to have it pasted to your currently focused app. The\n"
                 "emoji is also copied to the clipboard so you can then paste the emoji\n"
                 "wherever you need."
             )

--- a/emote/picker.py
+++ b/emote/picker.py
@@ -224,7 +224,7 @@ class EmojiPicker(Gtk.Window):
         self.connect("window-state-event", self.on_window_state_event)
 
     def on_window_state_event(self, widget, event):
-        """If the window has just unfocussed, exit"""
+        """If the window has just unfocused, exit"""
         if self.dialog_open:
             return
 
@@ -559,7 +559,7 @@ class EmojiPicker(Gtk.Window):
         """
         Copy the selected emoji to the clipboard, close the picker window and
         make the user's system perform a paste after 150ms, pasting the emoji
-        to the currently focussed application window.
+        to the currently focused application window.
 
         If we have been appending other emojis first, add this final one first.
         """


### PR DESCRIPTION
Hey, thanks for the great emoji picker :ok_hand:

Here is a small PR fixing a typo (see [focused](https://www.merriam-webster.com/dictionary/focused) / [unfocused](https://www.merriam-webster.com/dictionary/unfocused)) that I noticed after installing the AUR package. 

(By the way, how "unofficial" is it? :sweat_smile:)

Wishing you a nice day :handshake: 


