### PR TITLE
WIP: fix: use xdotool type instead of clipboard on X11 for inserting an emoji

### DIFF
--- a/emote/picker.py
+++ b/emote/picker.py
@@ -624,14 +624,15 @@ class EmojiPicker(Gtk.Window):
         else:
             print(f"Selecting {emoji}")
             self.add_emoji_to_recent(emoji)
-            self.copy_to_clipboard(emoji)
+            if config.is_wayland:
+                self.copy_to_clipboard(emoji)
 
         self.destroy()
 
         time.sleep(0.15)
 
         if not config.is_wayland:
-            os.system("xdotool key ctrl+v")
+            os.system(f'xdotool type --clearmodifiers "{emoji}"')
 
     def add_emoji_to_recent(self, emoji):
         user_data.update_recent_emojis(emoji)


### PR DESCRIPTION
This closes #41 and prevent polluting user clipboard unnecessarily (for X11 only).

I replaced the use of the clipboard by directly inserting the emoji with the command `xdotool type --clearmodifiers "{emoji}"`. The flag `--clearmodifiers` prevent special keys that could potentially be pressed to interact with what is typed. The clipboard is still populated on Wayland since xdotool does not work with it.