### PR TITLE
fix(picker): add fallback for skintone_id

### DIFF
--- a/emote/picker.py
+++ b/emote/picker.py
@@ -140,7 +140,10 @@ class EmojiPicker(Gtk.Window):
         for skintone in user_data.SKINTONES:
             skintone_combo.append_text(skintone)
 
-        skintone_combo.set_active(user_data.SKINTONES.index(user_data.load_skintone()))
+        skintone_id = 0
+        if user_data.load_skintone() in user_data.SKINTONES:
+            skintone_id = user_data.SKINTONES.index(user_data.load_skintone())
+        skintone_combo.set_active(skintone_id)
 
         return skintone_combo
 


### PR DESCRIPTION
Fixes: 
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/emote/__init__.py", line 72, in handle_accelerator
    self.create_picker_window()
  File "/usr/lib/python3.10/site-packages/emote/__init__.py", line 87, in create_picker_window
    self.picker_window = picker.EmojiPicker(
  File "/usr/lib/python3.10/site-packages/emote/picker.py", line 46, in __init__
    self.init_header()
  File "/usr/lib/python3.10/site-packages/emote/picker.py", line 77, in init_header
    header.pack_end(self.init_skintone_button())
  File "/usr/lib/python3.10/site-packages/emote/picker.py", line 135, in init_skintone_button
    skintone_combo.set_active(user_data.SKINTONES.index(user_data.load_skintone()))
ValueError: '🟨' is not in list
```