### PR TITLE
implement flatpak autostart

### DIFF
--- a/emote/__init__.py
+++ b/emote/__init__.py
@@ -1,5 +1,7 @@
+import os
 import sys
 import gi
+import shutil
 import manimpango
 from setproctitle import setproctitle
 
@@ -45,10 +47,25 @@ class EmoteApplication(Gtk.Application):
             self.create_picker_window(True)
             user_data.update_shown_welcome()
 
+        self.check_autostart()
         self.set_theme()
 
         # Run the main gtk event loop - this prevents the app from quitting
         Gtk.main()
+
+    def check_autostart(self):
+        """Create autostart entry if it doesn't exist"""
+        autostart_filename = "emote-autostart.desktop"
+        src_autostart_file = f"{config.flatpak_root}/static/{autostart_filename}"
+        autostart_dir = "~/.config/autostart/"
+        dest_autostart_file = f"{autostart_dir}{autostart_filename}"
+
+        try:
+            if not os.path.exists(dest_autostart_file):
+                shutil.copy2(src_autostart_file, os.path.expanduser(autostart_dir))
+                print("Created autostart entry")
+        except Exception as e:
+            print("Failed to create autostart entry", e)
 
     def set_accelerator(self):
         """Register global shortcut for invoking the emoji picker"""

--- a/flatpak/com.tomjwatson.Emote.yml
+++ b/flatpak/com.tomjwatson.Emote.yml
@@ -1,25 +1,24 @@
 app-id: com.tomjwatson.Emote
 runtime: org.gnome.Platform
-runtime-version: '43'
+runtime-version: "43"
 sdk: org.gnome.Sdk
 command: emote
 finish-args:
-    - --share=ipc
-    - --socket=wayland
-    - --socket=fallback-x11
-    # Enabling autostart: https://github.com/flatpak/flatpak/issues/118
-    # - --filesystem=xdg-config/autostart:create
-    - --device=dri
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --filesystem=xdg-config/autostart:create
+  - --device=dri
 cleanup:
-    - /include
-    - /lib/pkgconfig
-    - /man
-    - /share/doc
-    - /share/gtk-doc
-    - /share/man
-    - /share/pkgconfig
-    - "*.la"
-    - "*.a"
+  - /include
+  - /lib/pkgconfig
+  - /man
+  - /share/doc
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
+  - "*.la"
+  - "*.a"
 modules:
   - python3-requirements.json
   - name: keybinder-3.0

--- a/static/emote-autostart.desktop
+++ b/static/emote-autostart.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=Emote
+Type=Application
+GenericName=Emoji picker
+Comment=Modern popup emoji picker
+Exec=flatpak run com.tomjwatson.Emote
+Categories=Utility;GTK;
+Keywords=emoji,smiley,emoticon,icon
+Icon=com.tomjwatson.Emote
+Terminal=false
+StartupNotify=false
+X-Flatpak=com.tomjwatson.Emote
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
This implements flatpak autostart by adding the filesystem permission that vomonet had previously discovered, then having the app at runtime copy a .desktop file into ~/.config/autostart. It seems to be working as expected.