### PR TITLE
Migrate Snap to core22

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,16 +4,15 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-pygobject = "==3.38.0"
-manimpango = "==0.3.0"
-setproctitle = "==1.2.2"
+manimpango = "==0.4.0"
+setproctitle = "==1.3.2"
 
 [dev-packages]
 black = "==19.10b0"
 flake8 = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.10"
 
 [scripts]
 start = "python -m emote"

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
             "emote = emote.__init__:main",
         ]
     },
-    install_requires=["pygobject==3.36.0", "manimpango==0.3.0", "setproctitle==1.2.2"],
+    install_requires=["manimpango==0.4.3", "setproctitle==1.3.2"],
 )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,56 +8,33 @@ description: |
   out of your way.
 icon: snap/gui/emote.svg
 
-base: core18
+environment:
+  # Workaround for https://forum.snapcraft.io/t/python-plugin-gnome-3-extension-error/33396.
+  PYTHONPATH: ${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages:${PYTHONPATH}
+
+
+base: core22
 grade: stable # or devel. Must be 'stable' to release into candidate/stable channels
 confinement: strict # or devmode
-
 parts:
   emote:
     plugin: python
-    python-version: python3
     source: .
-    python-packages:
-      - wheel
-      - pygobject
-      - setuptools
+    build-environment:
+      # Workaround for https://forum.snapcraft.io/t/python-plugin-gnome-3-extension-error/33396.
+      - PATH: ${CRAFT_PART_INSTALL}/bin:${PATH}
+      - PYTHONPATH: ""
     build-packages:
       - python3-setuptools
       - python3-xlib
       - pkg-config
-    build-packages:
-      - libgirepository1.0-dev
     stage-packages:
-      - libcairo-gobject2
-      - libcairo2
-      - libfontconfig1
-      - libfreetype6
-      - libgirepository-1.0-1
-      - libpixman-1-0
-      - libpng16-16
-      - libx11-6
-      - libxau6
-      - libxcb-render0
-      - libxcb-shm0
-      - libxcb1
-      - libxdmcp6
-      - libxext6
-      - libxrender1
-      - libkeybinder-3.0-0
-      - gir1.2-keybinder-3.0
-      - python3-distutils-extra
-      - sound-theme-freedesktop
-      - pulseaudio-utils
+      # Core PyGObject dependencies.
       - python3-gi
-      - gir1.2-unity-5.0
-      - gir1.2-notify-0.7
+      - python3-gi-cairo
       - gir1.2-gtk-3.0
-      - gir1.2-pango-1.0
-      - appmenu-gtk2-module
-      - appmenu-gtk3-module
-      - libcanberra-gtk-module
-      - libcanberra-gtk3-module
-      # xdotool
+      # Dependencies for keybinding functionality.
+      - gir1.2-keybinder-3.0
       - xdotool
   static:
     plugin: dump
@@ -74,20 +51,6 @@ parts:
       - usr/share/applications/emote.desktop
       - usr/share/icons/emote.svg
 
-plugs:
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/share/themes
-    default-provider: gtk-common-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/share/icons
-    default-provider: gtk-common-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/share/sounds
-    default-provider: gtk-common-themes
-
 slots:
   dbus-daemon:
     interface: dbus
@@ -96,15 +59,11 @@ slots:
 
 apps:
   emote:
-    command: desktop-launch $SNAP/static/prepare-launch $SNAP/bin/emote
+    command: static/prepare-launch $SNAP/bin/emote
+    environment:
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
     desktop: usr/share/applications/emote.desktop
-    extensions: [gnome-3-28]
+    extensions: [gnome]
     slots: [dbus-daemon]
     common-id: com.tomjwatson.Emote
     autostart: emote.desktop
-    plugs:
-      - desktop
-      - desktop-legacy
-      - x11
-      - gsettings
-      - wayland

--- a/static/prepare-launch
+++ b/static/prepare-launch
@@ -10,4 +10,8 @@ fi
 # clipboard management do no yet work under wayland.
 export GDK_BACKEND="x11"
 
+# Workaround for https://bugs.launchpad.net/snapcraft/+bug/1998269.
+export FONTCONFIG_PATH=$SNAP/etc/fonts/config.d
+export FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
+
 exec "$@"


### PR DESCRIPTION
Migrates the base Snap to core22. core22 is bundled with Python 3.10 so I've had to update various dependencies. There's also quite a few issues with the Gnome extension so I've had to implement a couple of workaround (marked by comments). I've also removed a number of package dependencies because I couldn't figure out what they're for, but lmk if they are required (also halves the size of the snap).

Related to #48 and #63, hopefully unblocks new releases.

As a side note, we should be able to stop bundling the font file and instead use the user's system font instead. This would fix/alleviate issues like #83, #86, #71, and #67.

Due to https://forum.snapcraft.io/t/core22-gnome-extension-and-broken-symlinks/32900 it's necessary to use a pre-release version of Snapcraft to deploy the snap.
```
snap refresh --candidate snapcraft
```