### PR TITLE
Improve the flatpak-clean command and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ flatpak-validate:
 
 flatpak-clean:
 	rm -r .flatpak-builder build/
-	flatpak remove com.tomjwatson.Emote -y
+	flatpak remove com.tomjwatson.Emote -y --delete-data
 
 flathub:
 	flatpak-builder --repo=flathub --force-clean build flatpak/com.tomjwatson.Emote.yml

--- a/README.md
+++ b/README.md
@@ -146,22 +146,30 @@ Run Emote with flatpak (can also be done from the desktop entry):
 flatpak run com.tomjwatson.Emote
 ```
 
-**Build and publish to Flathub**:
+**Debug**:
 
-```bash
-make flathub
-```
-
-In case you are facing issues with the cache not properly updating, you can clean the cache with:
+In case you are facing issues with the cache not properly updating, or need to reset user data, you can clean the cache with:
 
 ```bash
 make flatpak-clean
 ```
 
-Use `journalctl -f` to see the app logs, run the command below if you want to access inside the containerized flatpak app to debug.
+To see potential error messages of the flatpak app you can use `journalctl`: 
+
+```bash
+journalctl -f -n 50
+```
+
+Run the command below if you want to access inside the containerized flatpak app to debug.
 
 ```bash
 flatpak run --command=sh --devel com.tomjwatson.Emote
+```
+
+**Build and publish to Flathub**:
+
+```bash
+make flathub
 ```
 
 ### 🤝 Attribution


### PR DESCRIPTION
@tom-james-watson thanks for all the improvements! (cf. https://github.com/tom-james-watson/Emote/pull/89) I have tried the last version and it works well

I updated the `make flatpak-clean` command to also delete user data when uninstalling the app (to make sure everything is properly reset when developing), and improved a bit the flatpak debug part in the readme 

Regarding the issues with the light/dark mode:

> I've actually switched my system to Fedora 38 (as opposed to Ubuntu 22.04 which is what I was running before). On this system the app doesn't seem to respect dark mode - it is always rendered in light mode. Not really sure why at this point. It seems like this is something that is handled a lot better if we use libadwaita, which would be part of the gtk4 migration.

On my laptop (Fedora 38) Emote uses the dark mode, which was what I set system-wide. But if I switch the system to light mode, Emote does not pick it up and stays in dark mode...

I could not find anything about light/dark mode in the codebase though, it is supposed to be handled automatically by GTK3? So if that bugs the best would be to work on GTK4 migration?

The next step now would be to publish to flathub then?