### PR TITLE
Add GitHub actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
         manifest-path: com.tomjwatson.Emote.yml
         cache-key: flatpak-builder-${{ github.sha }}
 
+    - run: |
+        flatpak run com.tomjwatson.Emote
 
   snap:
     name: Build Snap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,7 @@ jobs:
         manifest-path: com.tomjwatson.Emote.yml
         cache-key: flatpak-builder-${{ github.sha }}
 
-    - run: |
-        flatpak run com.tomjwatson.Emote
+    # - run: flatpak run com.tomjwatson.Emote
 
   snap:
     name: Build Snap
@@ -43,8 +42,7 @@ jobs:
     - run: |
         sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
 
-    - run: |
-        emote
+    # - run: emote
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build package
+on:
+  push:
+    tags:
+      - '*'
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+
+  flatpak:
+    name: Build Flatpak
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
+      with:
+        bundle: emote.flatpak
+        manifest-path: com.tomjwatson.Emote.yml
+        cache-key: flatpak-builder-${{ github.sha }}
+
+
+  snap:
+    name: Build Snap
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: snapcore/action-build@v1
+      id: build-snap
+
+    - run: |
+        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+
+    - run: |
+        emote
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: emote-pkg
+        path: ${{ steps.build-snap.outputs.snap }}
+
+#   publish:
+#     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+#     runs-on: ubuntu-latest
+#     needs: build
+#     steps:
+#     - uses: actions/download-artifact@v3
+#       with:
+#         name: emote-pkg
+#         path: .
+#     - uses: snapcore/action-publish@v1
+#       env:
+#         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
+#       with:
+#         snap: ${{needs.build.outputs.snap-file}}
+#         release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ flatpak:
 
 flatpak-install:
 	flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-	flatpak install flathub -y org.flatpak.Builder org.gnome.Platform//43 org.gnome.Sdk//43 org.freedesktop.appstream-glib
+	flatpak install flathub -y org.flatpak.Builder org.gnome.Platform//44 org.gnome.Sdk//44 org.freedesktop.appstream-glib
 	wget -N https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/pip/flatpak-pip-generator
 	chmod +x flatpak-pip-generator
 
 flatpak-requirements:
 	pipenv lock
 	pipenv requirements > requirements.txt
-	pipenv run ./flatpak-pip-generator --runtime='org.gnome.Sdk//43' --output python3-requirements -r requirements.txt
+	pipenv run ./flatpak-pip-generator --runtime='org.gnome.Sdk//44' --output python3-requirements -r requirements.txt
 	mv python3-requirements.json flatpak/python3-requirements.json
 
 flatpak-validate:

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [packages]
 manimpango = "==0.4.3"
 setproctitle = "==1.3.2"
+dbus-python = "==1.2.18"
 
 [dev-packages]
 black = "==23.3.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bb7ff92eb33d8c8fd680c2425baedafe4b7df6a27f13f03278b3dbac0ef22856"
+            "sha256": "04739af8aac9dd0b1ec5ddd71f682c9257825df53dcc379217b91a98f4c0ccc7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "dbus-python": {
+            "hashes": [
+                "sha256:92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"
+            ],
+            "index": "pypi",
+            "version": "==1.2.18"
+        },
         "manimpango": {
             "hashes": [
                 "sha256:138e4fc9805132b39c490e49327687b1518d9e4ccc7d3c34c8b40367605ec0d9",

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Previous Emoji Category: `Ctrl+Shift+Tab`
 
 ## 🧑‍💻 Development
 
+[![Build package](https://github.com/tom-james-watson/Emote/actions/workflows/build.yml/badge.svg)](https://github.com/tom-james-watson/Emote/actions/workflows/build.yml)
+
 ### 📥️ Requirements
 
 Install development libraries:

--- a/com.tomjwatson.Emote.yml
+++ b/com.tomjwatson.Emote.yml
@@ -32,7 +32,6 @@ modules:
       - WITHOUT_RPATH_FIX=1
     make-install-args:
       - PREFIX=${FLATPAK_DEST}
-      - INSTALLMAN=${FLATPAK_DEST}/share/man
     sources:
       - type: archive
         url: https://github.com/jordansissel/xdotool/archive/v3.20211022.1/xdotool-3.20211022.1.tar.gz
@@ -42,6 +41,8 @@ modules:
           project-id: 8648
           stable-only: true
           url-template: https://github.com/jordansissel/xdotool/archive/v$version/xdotool-$version.tar.gz
+    cleanup:
+      - /share/man
   - name: wl-clipboard
     buildsystem: meson
     config-opts:

--- a/com.tomjwatson.Emote.yml
+++ b/com.tomjwatson.Emote.yml
@@ -1,6 +1,6 @@
 app-id: com.tomjwatson.Emote
 runtime: org.gnome.Platform
-runtime-version: "43"
+runtime-version: "44"
 sdk: org.gnome.Sdk
 command: emote
 finish-args:

--- a/com.tomjwatson.Emote.yml
+++ b/com.tomjwatson.Emote.yml
@@ -7,7 +7,6 @@ finish-args:
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11
-  - --filesystem=xdg-config/autostart:create
   - --device=dri
 cleanup:
   - /include

--- a/flatpak/python3-requirements.json
+++ b/flatpak/python3-requirements.json
@@ -4,6 +4,20 @@
     "build-commands": [],
     "modules": [
         {
+            "name": "python3-dbus-python",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-python==1.2.18\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b1/5c/ccfc167485806c1936f7d3ba97db6c448d0089c5746ba105b6eb22dba60e/dbus-python-1.2.18.tar.gz",
+                    "sha256": "92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"
+                }
+            ]
+        },
+        {
             "name": "python3-manimpango",
             "buildsystem": "simple",
             "build-commands": [

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
             "emote = emote.__init__:main",
         ]
     },
-    install_requires=["manimpango==0.4.3", "setproctitle==1.3.2"],
+    install_requires=["manimpango==0.4.3", "setproctitle==1.3.2", "dbus-python==1.2.18"],
 )


### PR DESCRIPTION
Added a GitHub actions workflow to test building the package with snap and flatpak

It should already help to catch some errors and test building emote in specific environment

Not sure how we could test if the package was built properly though.

Trying to run the command in the workflow fails: https://github.com/vemonet/Emote/actions/runs/5313394035

* For **flatpak**: https://github.com/vemonet/Emote/actions/runs/5313394035

```
error: app/com.tomjwatson.Emote/x86_64/master not installed
Error: Process completed with exit code 1.
```

* For **snap**:

```
/snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/glib-2.0/glib-compile-schemas: symbol lookup error: /snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/glib-2.0/glib-compile-schemas: undefined symbol: g_task_set_static_name
Cannot load module /snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-wayland.so: /snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-wayland.so: undefined symbol: g_string_free_and_steal
/snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-wayland.so does not export GTK+ IM module API: /snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-wayland.so: undefined symbol: g_string_free_and_steal
ERROR: compile_schemas /snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/glib-2.0/glib-compile-schemas exited abnormally with status 127
ERROR: /snap/emote/x1/gnome-platform/usr/lib/x86_64-linux-gnu/libgtk-3-0/gtk-query-immodules-3.0 exited abnormally with status 1

(emote:12085): Gtk-WARNING **: 15:05:34.326: cannot open display: 
Error: Process completed with exit code 1.
```