### PR TITLE
Initialize shelve file if does not exist

### DIFF
--- a/emote/user_data.py
+++ b/emote/user_data.py
@@ -71,7 +71,10 @@ SKINTONES = ["✋", "✋🏻", "✋🏼", "✋🏽", "✋🏾", "✋🏿"]
 
 # Ensure the data dir exists
 os.makedirs(DATA_DIR, exist_ok=True)
-
+# Initialize shelve file if does not exist
+if not os.path.exists(SHELVE_PATH):
+    with shelve.open(SHELVE_PATH) as db:
+        db[RECENT_EMOJIS] = DEFAULT_RECENT_EMOJIS
 
 def load_recent_emojis():
     with shelve.open(SHELVE_PATH) as db:


### PR DESCRIPTION
Fix issue in build [48611 successful](https://buildbot.flathub.org/#/builders/6/builds/48611)

```
Jun 19 19:52:52 bad-lenovo emote[18668]: Failed to load module "pk-gtk-module"
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]: Traceback (most recent call last):
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/app/share/emote/emote/__init__.py", line 120, in do_activate
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     self.create_picker_window()
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/app/share/emote/emote/__init__.py", line 103, in create_picker_window
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     self.picker_window = picker.EmojiPicker(
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/app/share/emote/emote/picker.py", line 54, in __init__
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     self.init_header()
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/app/share/emote/emote/picker.py", line 85, in init_header
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     header.pack_end(self.init_skintone_button())
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/app/share/emote/emote/picker.py", line 143, in init_skintone_button
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     skintone_combo.set_active(user_data.load_skintone_index())
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/app/share/emote/emote/user_data.py", line 130, in load_skintone_index
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     with shelve.open(SHELVE_PATH) as db:
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/usr/lib/python3.10/shelve.py", line 243, in open
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     return DbfilenameShelf(filename, flag, protocol, writeback)
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/usr/lib/python3.10/shelve.py", line 227, in __init__
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     Shelf.__init__(self, dbm.open(filename, flag), protocol, writeback)
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:   File "/usr/lib/python3.10/dbm/__init__.py", line 95, in open
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]:     return mod.open(file, flag, mode)
Jun 19 19:52:52 bad-lenovo com.tomjwatson.Emote.desktop[4175]: _gdbm.error: [Errno 2] No such file or directory: '/home/vemonet/.var/app/com.tomjwatson.Emote/data/user_data'
```

To test:

```
flatpak install --user https://dl.flathub.org/build-repo/31211/com.tomjwatson.Emote.flatpakref
```