### PR TITLE
Add error handling for flatpak autostart to revert to old way on systems with xdg-desktop-portal implementation issues

### DIFF
--- a/com.tomjwatson.Emote.yml
+++ b/com.tomjwatson.Emote.yml
@@ -7,6 +7,7 @@ finish-args:
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11
+  - --filesystem=xdg-config/autostart:create
   - --device=dri
 cleanup:
   - /include


### PR DESCRIPTION
One second.