### PR TITLE
Snap font issue fix #115

### DIFF
--- a/static/prepare-launch
+++ b/static/prepare-launch
@@ -15,7 +15,7 @@ export GDK_BACKEND="x11"
 # If we apply this fix on other systems then fonts end up messed up.
 if [ -f /etc/lsb-release ]; then
   echo "Running on an Ubuntu-derived system, trying to fix font issue."
-  export FONTCONFIG_PATH=$SNAP/etc/fonts/config.d
+  export FONTCONFIG_PATH=$SNAP/etc/fonts
   export FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
 else
   echo "Not running on an Ubuntu-derived system. Nothing to do."


### PR DESCRIPTION
After seeing @larowlan's [comment](https://github.com/tom-james-watson/Emote/issues/115#issuecomment-1624425165), I thought that he might be onto something, so I took a look at the [Font configuration and customization library](https://gitlab.freedesktop.org/search?search=FONTCONFIG_PATH&nav_source=navbar&project_id=890&group_id=1174&search_code=true&repository_ref=main) code. It appears that `FONTCONFIG_PATH` should point to the base config directory `$SNAP/etc/fonts` instead of `$SNAP/etc/fonts/config.d`.

Changed the path, built a new snap and voilà, the font issue disappeared.

I'm using Ubuntu 23.04 with Gnome 44 and X11. It would be great if someone who previously experienced the tiny font issue could also test this fix.

```bash
# uninstall the official snap
snap remove emote

# install the test snap
curl -O --output-dir /tmp https://cdn.dobicinaitis.dev/tmp/emote_4.0.2_amd64_font_fix.snap
snap install --dangerous /tmp/emote_4.0.2_amd64_font_fix.snap

# test ... 🤞

# restore the original version
snap remove emote
snap install emote
```