### PR TITLE
Move distribution-based logic to config.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ flatpak-pip-generator
 
 # Editors
 .vim
+
+# Python
+__pycache__

--- a/emote/config.py
+++ b/emote/config.py
@@ -8,3 +8,55 @@ snap_root = os.environ.get("SNAP")
 is_flatpak = os.environ.get("FLATPAK") is not None
 flatpak_root = os.environ.get("FLATPAK")
 is_wayland = os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland"
+
+version = os.environ.get("FLATPAK_APP_VERSION", os.environ.get("SNAP_VERSION", "dev build"))
+
+css_path = (
+    f"{snap_root}/static/style.css"
+    if is_snap
+    else f"{flatpak_root}/static/style.css"
+    if is_flatpak
+    else "static/style.css"
+)
+
+emoji_path = (
+    f"{snap_root}/static/emojis.csv"
+    if is_snap
+    else f"{flatpak_root}/static/emojis.csv"
+    if is_flatpak
+    else "static/emojis.csv"
+)
+
+logo_path = (
+    f"{snap_root}/static/logo.svg"
+    if is_snap
+    else f"{flatpak_root}/static/logo.svg"
+    if is_flatpak
+    else "static/logo.svg"
+)
+
+version = os.environ.get("FLATPAK_APP_VERSION", os.environ.get("SNAP_VERSION", "dev build"))
+
+css_path = (
+    f"{snap_root}/static/style.css"
+    if is_snap
+    else f"{flatpak_root}/static/style.css"
+    if is_flatpak
+    else "static/style.css"
+)
+
+emoji_path = (
+    f"{snap_root}/static/emojis.csv"
+    if is_snap
+    else f"{flatpak_root}/static/emojis.csv"
+    if is_flatpak
+    else "static/emojis.csv"
+)
+
+logo_path = (
+    f"{snap_root}/static/logo.svg"
+    if is_snap
+    else f"{flatpak_root}/static/logo.svg"
+    if is_flatpak
+    else "static/logo.svg"
+)

--- a/emote/css.py
+++ b/emote/css.py
@@ -12,12 +12,7 @@ def load_css():
     """
     css_provider = Gtk.CssProvider()
 
-    if config.is_snap:
-        css_provider.load_from_path(f"{config.snap_root}/static/style.css")
-    elif config.is_flatpak:
-        css_provider.load_from_path(f"{config.flatpak_root}/static/style.css")
-    else:
-        css_provider.load_from_path("static/style.css")
+    css_provider.load_from_path(config.css_path)
 
     screen = Gdk.Screen.get_default()
     styleContext = Gtk.StyleContext()

--- a/emote/emojis.py
+++ b/emote/emojis.py
@@ -50,13 +50,7 @@ def process_emoji_row(row):
 
 
 def init():
-    filename = (
-        f"{config.snap_root}/static/emojis.csv"
-        if config.is_snap
-        else f"{config.flatpak_root}/static/emojis.csv"
-        if config.is_flatpak
-        else "static/emojis.csv"
-    )
+    filename = config.emoji_path
 
     with open(filename, newline="") as csvfile:
         reader = csv.DictReader(csvfile)

--- a/emote/picker.py
+++ b/emote/picker.py
@@ -344,13 +344,7 @@ class EmojiPicker(Gtk.Window):
         guide_window.connect("destroy", self.on_close_dialog)
 
     def open_about(self):
-        logo_path = (
-            f"{config.snap_root}/static/logo.svg"
-            if config.is_snap
-            else f"{config.flatpak_root}/static/logo.svg"
-            if config.is_flatpak
-            else "static/logo.svg"
-        )
+        logo_path = config.logo_path
         logo = Pixbuf.new_from_file(logo_path)
 
         about_dialog = Gtk.AboutDialog(
@@ -359,7 +353,7 @@ class EmojiPicker(Gtk.Window):
             logo=logo,
             program_name="Emote",
             title="About Emote",
-            version=os.environ.get("FLATPAK_APP_VERSION", os.environ.get("SNAP_VERSION", "dev build")),
+            version=config.version,
             authors=["Tom Watson", "Vincent Emonet"],
             artists=["Tom Watson, Matthew Wong"],
             documenters=["Irene Auñón"],
@@ -373,6 +367,7 @@ class EmojiPicker(Gtk.Window):
         self.dialog_open = True
         about_dialog.present()
         about_dialog.connect("destroy", self.on_close_dialog)
+        about_dialog.connect('response', lambda dialog, response: about_dialog.destroy())
 
     def on_close_dialog(self, dialog):
         self.dialog_open = False


### PR DESCRIPTION
As mentioned in #147, this moves anything that changes based on the distribution format of the picker to config.py to make it easier for porting to other distributions and increase maintainability. I have tested the commits in all 3 distribution formats, and there is no change to functionality.

Once again, thank you for your hard work on this project. It really feels like the least terrible emoji picker on Linux.