### PR TITLE
Update runtime version and appdata fixes

### DIFF
--- a/com.tomjwatson.Emote.yml
+++ b/com.tomjwatson.Emote.yml
@@ -1,6 +1,6 @@
 app-id: com.tomjwatson.Emote
 runtime: org.gnome.Platform
-runtime-version: "44"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 command: emote
 finish-args:
@@ -49,8 +49,8 @@ modules:
       - -Dfishcompletiondir=no
     sources:
       - type: archive
-        url: https://github.com/bugaevc/wl-clipboard/archive/v2.1.0.tar.gz
-        sha256: 72dab9a7d3835c76d6ff2089f15ffec9e064a321e5f3cbbe961a8fa81aff5573
+        url: https://github.com/bugaevc/wl-clipboard/archive/v2.2.1.tar.gz
+        sha256: 6eb8081207fb5581d1d82c4bcd9587205a31a3d47bea3ebeb7f41aa1143783eb
         x-checker-data:
           type: anitya
           project-id: 49082

--- a/flatpak/com.tomjwatson.Emote.metainfo.xml
+++ b/flatpak/com.tomjwatson.Emote.metainfo.xml
@@ -9,7 +9,10 @@
 
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  <developer_name translatable="no">Tom Watson</developer_name>
+  <developer_name translate="no">Tom Watson</developer_name>
+  <developer id="io.github.tom-james-watson">
+    <name translate="no">Tom Watson<name>
+  </developer>
 
   <description>
     <p>
@@ -36,7 +39,7 @@
       ⚡️ Emote shows up faster when invoked using the built-in keyboard shortcut (`Ctrl+Alt+E` by default), than when using a manually registered keyboard shortcut.
     </p>
     <p>
-      🪟 Emote under Wayland cannot automatically paste the emoji into other apps, and also requires manual registering of a global keyboard shortcut - <a href="https://github.com/tom-james-watson/Emote/wiki/Hotkey-In-Wayland" target="_blank">Hotkey In Wayland</a>. This is due to intentional restrictions in the design of Wayland itself.
+      🪟 Emote under Wayland cannot automatically paste the emoji into other apps, and also requires manual registering of a global keyboard shortcut - (Hotkey In Wayland - github.com/tom-james-watson/Emote/wiki/Hotkey-In-Wayland). This is due to intentional restrictions in the design of Wayland itself.
     </p>
   </description>
 
@@ -76,8 +79,7 @@
     <control>pointing</control>
     <control>keyboard</control>
     <control>touch</control>
-    <display_length compare="ge">small</display_length>
-    <display_length compare="le">xlarge</display_length>
+    <display_length compare="ge">512</display_length>
   </supports>
   <!-- https://hughsie.github.io/oars/generate.html -->
   <content_rating type="oars-1.1" />


### PR DESCRIPTION
### Update runtime version

- Update Emoto runtime to 46
- Update wl-clipboard to 2.2.1

### appdata: Fix appdata papercuts

- Use `translate="no"` property to mark strings as untranslatable
- Add developer block with io.github.tom-james-watson ID
- Fix named display_length tags
- Fix URL in description issue