### PR TITLE
Add configurable window position setting

### DIFF
--- a/emote/picker.py
+++ b/emote/picker.py
@@ -26,12 +26,21 @@ def grouper(iterable, n, fillvalue=None):
     return zip_longest(*args, fillvalue=fillvalue)
 
 
+WINDOW_POSITION_MAP = {
+    "Center": Gtk.WindowPosition.CENTER,
+    "Mouse Cursor": Gtk.WindowPosition.MOUSE,
+}
+
+
 class EmojiPicker(Gtk.Window):
     def __init__(self, open_time, update_accelerator, update_theme, show_welcome):
+        window_position = WINDOW_POSITION_MAP.get(
+            user_data.load_window_position(), Gtk.WindowPosition.CENTER
+        )
         Gtk.Window.__init__(
             self,
             title="Emote",
-            window_position=Gtk.WindowPosition.CENTER,
+            window_position=window_position,
             resizable=False,
             deletable=False,
             name="emote_window",

--- a/emote/settings.py
+++ b/emote/settings.py
@@ -47,6 +47,21 @@ class Settings(Gtk.Dialog):
         settings_grid.attach(theme_combo, 2, row, 1, 1)
         row += 1
 
+        window_position_label = Gtk.Label("Window Position")
+        window_position_label.set_alignment(0, 0.5)
+        settings_grid.attach(window_position_label, 1, row, 1, 1)
+
+        window_position_combo = Gtk.ComboBoxText()
+        window_position_combo.set_entry_text_column(0)
+        window_position_combo.connect("changed", self.on_window_position_combo_changed)
+        for position in user_data.WINDOW_POSITIONS:
+            window_position_combo.append_text(position)
+        window_position_combo.set_active(
+            user_data.WINDOW_POSITIONS.index(user_data.load_window_position())
+        )
+        settings_grid.attach(window_position_combo, 2, row, 1, 1)
+        row += 1
+
         box.pack_start(settings_grid, True, True, GRID_SIZE)
 
         self.show_all()
@@ -57,3 +72,9 @@ class Settings(Gtk.Dialog):
 
         if theme is not None:
             self.update_theme(theme)
+
+    def on_window_position_combo_changed(self, combo):
+        window_position = combo.get_active_text()
+
+        if window_position is not None:
+            user_data.update_window_position(window_position)

--- a/emote/user_data.py
+++ b/emote/user_data.py
@@ -68,6 +68,10 @@ SKINTONE_INDEX = "skintone_index"
 DEFAULT_SKINTONE_INDEX = 0
 SKINTONES = ["✋", "✋🏻", "✋🏼", "✋🏽", "✋🏾", "✋🏿"]
 
+WINDOW_POSITION = "window_position"
+DEFAULT_WINDOW_POSITION = "Center"
+WINDOW_POSITIONS = ["Center", "Mouse Cursor"]
+
 
 # Ensure the data dir exists
 os.makedirs(DATA_DIR, exist_ok=True)
@@ -134,3 +138,13 @@ def load_skintone_index():
 def update_skintone_index(skintone):
     with shelve.open(SHELVE_PATH) as db:
         db[SKINTONE_INDEX] = skintone
+
+
+def load_window_position():
+    with shelve.open(SHELVE_PATH) as db:
+        return db.get(WINDOW_POSITION, DEFAULT_WINDOW_POSITION)
+
+
+def update_window_position(window_position):
+    with shelve.open(SHELVE_PATH) as db:
+        db[WINDOW_POSITION] = window_position


### PR DESCRIPTION
## Summary

Adds a **Window Position** preference to the Settings dialog with two options:
- **Center** (default) - existing behavior, opens centered on the primary monitor
- **Mouse Cursor** (`Gtk.WindowPosition.MOUSE`) - opens on the monitor where the mouse cursor currently is

**Problem:** On multi-monitor setups, the picker always opens centered on the primary monitor, even when the user is working on a different screen.

**Scope:** This PR ensures the picker opens on the **correct monitor** (where the mouse is). Note that on Wayland, the compositor controls exact window placement - `Gtk.WindowPosition.MOUSE` tells GTK which monitor to use, but the compositor (e.g. Mutter) determines the exact position within that monitor. Precise cursor-following positioning would require Wayland-specific APIs (e.g. `xdg-positioner` or layer-shell) which is outside the scope of this change.

Follows existing patterns for settings (theme, skintone) - stored via `shelve` in `user_data.py`, exposed as a combo box in `settings.py`.

## Changes

- `emote/user_data.py` - window position constants, `load_window_position()`, `update_window_position()`
- `emote/settings.py` -"Window Position" combo box in Preferences
- `emote/picker.py` - use configured position instead of hardcoded `CENTER`

## How was tested

- Open Emote with default settings → picker opens centered (no behavior change)
- Open Preferences → change Window Position to "Mouse Cursor" → close Preferences
- Open Emote again → picker opens on the monitor where the cursor is
- Restart Emote → setting persists
- Test on multi-monitor setup (4 monitors): picker appears on the correct monitor